### PR TITLE
fixed run.sh and run.cmd to accept variable-length CLI parameters

### DIFF
--- a/sandbox/run.cmd
+++ b/sandbox/run.cmd
@@ -1,2 +1,2 @@
-java -cp "target/classes;target/eo-runtime.jar" org.eolang.phi.Main sandbox.app $1
+java -cp "target/classes;target/eo-runtime.jar" org.eolang.phi.Main sandbox.app %*
 pause

--- a/sandbox/run.sh
+++ b/sandbox/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-java -cp target/classes:target/eo-runtime.jar org.eolang.phi.Main sandbox.app $1
+java -cp target/classes:target/eo-runtime.jar org.eolang.phi.Main sandbox.app "$@"


### PR DESCRIPTION
Fixes #196 
### The Solution
The solution is plain: `run.cmd` and `run.sh` have to consider variable-length CLI parameters, not just the first of them.
#### *nix
Use `"$@"` instead of `$1`.
#### Windows
Use `%*` instead of `$1`
### Tests
#### Program that Consumes Variable-Length CLI Parameters 
The first test is the program described in #196 
##### *nix
###### Before
```
./run.sh 1 2 3 4 5
Exception in thread "main" java.lang.IllegalArgumentException: Can't get() the 1th element of the array, there are just 1 of them
  at org.eolang.EOarray$EOget.lambda$new$0(EOarray$EOget.java:53)
```
###### After
```
./run.sh 1 2 3 4 5
1
2
3
4
5
```
##### Windows 
###### Before
```
> .\run.cmd 1 2 3 4 5       
>>> java -cp "target/classes;target/eo-runtime.jar" org.eolang.phi.Main sandbox.app $1
Exception in thread "main" java.lang.NumberFormatException: For input string: "$1"
at java.lang.NumberFormatException.forInputString(Unknown Source)
at java.lang.Long.parseLong(Unknown Source)
at java.lang.Long.parseLong(Unknown Source)                                                                
```
###### After
```
> .\run.cmd 1 2 3 4 5                                                                                                                                                                                                                                            >>>java -cp "target/classes;target/eo-runtime.jar" org.eolang.phi.Main sandbox.app 1 2 3 4 5            
1                                                                                                                                                            
2                                                                                                                                                             
3                                                                                                                                                             
4                                                                                                                                                             
5                                                                                                                                                                                                                                                                                                                           >>>pause
Press any key to continue . . .
```
#### Program that Consumes One CLI Parameter 
This is a regression test. Here, we test that the `sandbox/eo/app.eo` still works (this is the Fibonacci example).
##### *nix
###### Before
```
$ ./run.sh 10
10th Fibonacci number is 55
$
```
###### After
```
$ ./run.sh 10
10th Fibonacci number is 55
$
```
##### Windows 
###### Before
```
> .\run.cmd 10 
>>> java -cp "target/classes;target/eo-runtime.jar" org.eolang.phi.Main sandbox.app $1
Exception in thread "main" java.lang.NumberFormatException: For input string: "$1"
at java.lang.NumberFormatException.forInputString(Unknown Source)
at java.lang.Long.parseLong(Unknown Source)
at java.lang.Long.parseLong(Unknown Source)                                                                
```
###### After
```
> .\run.cmd 10                                                                                                                                                                                                                                           >>>java -cp "target/classes;target/eo-runtime.jar" org.eolang.phi.Main sandbox.app 10            
10th Fibonacci number is 55
>>>pause
Press any key to continue . . .
```