### PR TITLE
changed signature of `and` and `or` to accept one argument

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/bool.eo
+++ b/eo-runtime/src/main/eo/org/eolang/bool.eo
@@ -9,10 +9,10 @@
   [] > not /bool
 
   # AND
-  [x...] > and /bool
+  [x] > and /bool
 
   # OR
-  [x...] > or /bool
+  [x] > or /bool
 
   # While this is true copies the object
   # with "i" as the position of the cycle. The result


### PR DESCRIPTION
— because these are binary operations.

I propose either this alternative or the one in another pull request