### PR TITLE
changed signature of `add` and `mul` for `int` and `float` to accept varargs

### DIFF
--- a/eo-runtime/src/main/eo/org/eolang/float.eo
+++ b/eo-runtime/src/main/eo/org/eolang/float.eo
@@ -20,11 +20,11 @@
   # Tests that $ ≥ x
   [x] > geq /bool
 
-  # Multiplication of $ and x
-  [x] > mul /float
+  # Multiplication of $ and elements of x
+  [x...] > mul /float
 
-  # Sum of $ and x
-  [x] > add /float
+  # Sum of $ and elements of x
+  [x...] > add /float
 
   # Negation of $
   [] > neg /float

--- a/eo-runtime/src/main/eo/org/eolang/int.eo
+++ b/eo-runtime/src/main/eo/org/eolang/int.eo
@@ -23,15 +23,15 @@
   # Change the sign of the number
   [] > neg /int
 
-  # Add to the current one
-  [x] > add /int
+  # Sum of $ and elements of x
+  [x...] > add /int
 
   # Subtract from the current one
   [x] > sub
     ^.add (x.neg) > @
 
-  # Multiply this one by another int
-  [x] > mul /int
+  # Multiplication of $ and elements of x
+  [x...] > mul /int
 
   # Divide this one by another int
   [x] > div /int


### PR DESCRIPTION
— because it was inferred so from examples, and also matches with the existing definition of binary boolean operations (`and` and `or`)

I propose either this alternative or the one in another pull request.