### PR TITLE
fix a wrong "too many free attributes" error + fix an overly eager junit.xsl renamer pass

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/junit.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/pre/junit.xsl
@@ -51,7 +51,28 @@ SOFTWARE.
       </xsl:choose>
     </xsl:attribute>
   </xsl:template>
-  <xsl:template match="o/@base | class/@parent">
+  <xsl:template match="o/@base">
+    <xsl:variable name="a" select="."/>
+    <xsl:variable name="ourRef" select="parent::o/@ref"/>
+    <xsl:attribute name="{name()}">
+      <xsl:choose>
+        <xsl:when test="//meta[head='junit']">
+          <xsl:choose>
+            <xsl:when test="//class[@name=$a and @line=$ourRef]">
+              <xsl:value-of select="eo:name($a)"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="."/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:attribute>
+  </xsl:template>
+  <xsl:template match="class/@parent">
     <xsl:variable name="a" select="."/>
     <xsl:attribute name="{name()}">
       <xsl:choose>

--- a/eo-parser/src/main/resources/org/eolang/parser/errors/many-free-attributes.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/errors/many-free-attributes.xsl
@@ -26,7 +26,7 @@ SOFTWARE.
   <xsl:template match="/program/errors">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
-      <xsl:for-each select="//o[count(o[@name and not(@base) and not(@atom)]) &gt; 4]">
+      <xsl:for-each select="//o[count(o[@name and not(@base) and not(@atom) and count(o)=0]) &gt; 4]">
         <xsl:element name="error">
           <xsl:attribute name="check">
             <xsl:text>too-many-attributes</xsl:text>

--- a/eo-runtime/src/test/eo/org/eolang/junit-renaming-bug.eo
+++ b/eo-runtime/src/test/eo/org/eolang/junit-renaming-bug.eo
@@ -1,0 +1,12 @@
++package org.eolang
++alias org.eolang.txt.sprintf
++alias org.eolang.io.stdout
++junit
+
+[] > x
+  TRUE > @
+
+[] > z
+  [x] > y
+    x > @
+  TRUE > @

--- a/eo-runtime/src/test/eo/org/eolang/test-many-free-attributes.eo
+++ b/eo-runtime/src/test/eo/org/eolang/test-many-free-attributes.eo
@@ -5,7 +5,7 @@
 
 # this code should not fail the many-free-attributes check
 # because every abstract object clearly has <= 4 free attrs 
-[] > many-free-attributes
+[] > not-many-free-attributes
   [] > empty1
     TRUE > @
   [] > empty2
@@ -17,4 +17,10 @@
   [] > empty5
     TRUE > @
   TRUE > @
+
+# this one should still fail
+#[] > many-free-attributes
+#  [a b c d e f] > too-many
+#    TRUE > @
+#  TRUE > @
 

--- a/eo-runtime/src/test/eo/org/eolang/test-many-free-attributes.eo
+++ b/eo-runtime/src/test/eo/org/eolang/test-many-free-attributes.eo
@@ -18,9 +18,3 @@
     TRUE > @
   TRUE > @
 
-# this one should still fail
-#[] > many-free-attributes
-#  [a b c d e f] > too-many
-#    TRUE > @
-#  TRUE > @
-

--- a/eo-runtime/src/test/eo/org/eolang/test-many-free-attributes.eo
+++ b/eo-runtime/src/test/eo/org/eolang/test-many-free-attributes.eo
@@ -1,0 +1,20 @@
++package org.eolang
++alias org.eolang.txt.sprintf
++alias org.eolang.io.stdout
++junit
+
+# this code should not fail the many-free-attributes check
+# because every abstract object clearly has <= 4 free attrs 
+[] > many-free-attributes
+  [] > empty1
+    TRUE > @
+  [] > empty2
+    TRUE > @
+  [] > empty3
+    TRUE > @
+  [] > empty4
+    TRUE > @
+  [] > empty5
+    TRUE > @
+  TRUE > @
+


### PR DESCRIPTION
The error should happen in case an object has > 4 free attributes, but it also happens for the test below (zero free attributes!). This is because the check counts some XML nodes, which are not actually free attributes, but happen to have the same XML attributes. 
```
[] > not-many-free-attributes
  [] > empty1
    TRUE > @
  [] > empty2
    TRUE > @
  [] > empty3
    TRUE > @
  [] > empty4
    TRUE > @
  [] > empty5
    TRUE > @
  TRUE > @
```