### PR TITLE
(#268) - Checkstyle & PMD fixes

### DIFF
--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOpow.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOpow.java
@@ -42,9 +42,9 @@ public class EOfloat$EOpow extends PhDefault {
         super(sigma);
         this.add("x", new AtFree());
         this.add("φ", new AtComposite(this, self -> {
-            final double ρ = new Dataized(self.attr("ρ").get()).take(Double.class);
+            final double rho = new Dataized(self.attr("ρ").get()).take(Double.class);
             final double x = new Dataized(self.attr("x").get()).take(Double.class);
-            return new Data.ToPhi(Math.pow(ρ, x));
+            return new Data.ToPhi(Math.pow(rho, x));
         }));
     }
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOpow.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOint$EOpow.java
@@ -43,13 +43,13 @@ public class EOint$EOpow extends PhDefault {
         super(sigma);
         this.add("x", new AtFree());
         this.add("φ", new AtComposite(this, self -> {
-            final long ρ = new Dataized(self.attr("ρ").get()).take(Long.class);
+            final long rho = new Dataized(self.attr("ρ").get()).take(Long.class);
             final long x = new Dataized(self.attr("x").get()).take(Long.class);
-            if (ρ == 0L && x < 0L) {
+            if (rho == 0L && x < 0L) {
                 final Phi msg = new Data.ToPhi("0 cannot be raised to a negative power");
                 return new PhWith(new EOerror(Phi.Φ), "msg", msg);
             }
-            return new Data.ToPhi((long) Math.pow(ρ, x));
+            return new Data.ToPhi((long) Math.pow(rho, x));
         }));
     }
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOmemory.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOmemory.java
@@ -48,7 +48,7 @@ public class EOmemory extends PhDefault {
         this.add("φ", new AtComposite(this, rho -> {
             final Phi object = this.phi.get();
             if (object == null) {
-                throw new Attr.Exception(
+                throw new Attr.IllegalAttrException(
                     "The memory is not yet written"
                 );
             }

--- a/eo-runtime/src/main/java/org/eolang/AtComposite.java
+++ b/eo-runtime/src/main/java/org/eolang/AtComposite.java
@@ -75,12 +75,13 @@ public final class AtComposite implements Attr {
      * @param exp The \lambda expression
      * @param rho The \rho of this attribute/object
      * @return Data
+     * @checkstyle IllegalCatchCheck (20 lines)
      */
     private static Data<Phi> toData(final Expr exp, final Phi rho) {
         return () -> {
             try {
                 return exp.get(rho);
-            } catch (final java.lang.Exception ex) {
+            } catch (final Exception ex) {
                 throw new IllegalArgumentException(ex);
             }
         };

--- a/eo-runtime/src/main/java/org/eolang/AtNamed.java
+++ b/eo-runtime/src/main/java/org/eolang/AtNamed.java
@@ -52,8 +52,8 @@ public final class AtNamed implements Attr {
     public Attr copy(final Phi self) {
         try {
             return new AtNamed(this.name, this.phi, this.origin.copy(self));
-        } catch (final Attr.Exception ex) {
-            throw new Attr.Exception(this.label(), ex);
+        } catch (final IllegalAttrException ex) {
+            throw new IllegalAttrException(this.label(), ex);
         }
     }
 
@@ -63,8 +63,8 @@ public final class AtNamed implements Attr {
             return this.origin.get();
         } catch (final Attr.StillAbstractException ex) {
             throw new Attr.StillAbstractException(this.label(), ex);
-        } catch (final Attr.Exception ex) {
-            throw new Attr.Exception(this.label(), ex);
+        } catch (final IllegalAttrException ex) {
+            throw new IllegalAttrException(this.label(), ex);
         }
     }
 
@@ -74,8 +74,8 @@ public final class AtNamed implements Attr {
             this.origin.put(src);
         } catch (final Attr.ReadOnlyException ex) {
             throw new Attr.ReadOnlyException(this.label(), ex);
-        } catch (final Attr.Exception ex) {
-            throw new Attr.Exception(this.label(), ex);
+        } catch (final IllegalAttrException ex) {
+            throw new IllegalAttrException(this.label(), ex);
         }
     }
 

--- a/eo-runtime/src/main/java/org/eolang/Attr.java
+++ b/eo-runtime/src/main/java/org/eolang/Attr.java
@@ -59,15 +59,15 @@ public interface Attr {
      *
      * @since 0.1
      */
-    final class Exception extends RuntimeException {
+    final class IllegalAttrException extends RuntimeException {
 
         private static final long serialVersionUID = 597749420437007615L;
 
-        public Exception(final String cause) {
+        public IllegalAttrException(final String cause) {
             super(cause);
         }
 
-        public Exception(final String cause, final Throwable root) {
+        public IllegalAttrException(final String cause, final Throwable root) {
             super(cause, root);
         }
     }

--- a/eo-runtime/src/main/java/org/eolang/Attr.java
+++ b/eo-runtime/src/main/java/org/eolang/Attr.java
@@ -60,10 +60,13 @@ public interface Attr {
      * @since 0.1
      */
     final class Exception extends RuntimeException {
+
         private static final long serialVersionUID = 597749420437007615L;
+
         public Exception(final String cause) {
             super(cause);
         }
+
         public Exception(final String cause, final Throwable root) {
             super(cause, root);
         }
@@ -76,13 +79,13 @@ public interface Attr {
      * @since 0.13
      */
     final class StillAbstractException extends RuntimeException {
+
         private static final long serialVersionUID = 597748420437017615L;
+
         public StillAbstractException(final String cause) {
             super(cause);
         }
-        public StillAbstractException(final Throwable cause) {
-            super(cause);
-        }
+
         public StillAbstractException(final String cause, final Throwable root) {
             super(cause, root);
         }
@@ -95,13 +98,13 @@ public interface Attr {
      * @since 0.13
      */
     final class ReadOnlyException extends RuntimeException {
+
         private static final long serialVersionUID = 697748420437017615L;
+
         public ReadOnlyException(final String cause) {
             super(cause);
         }
-        public ReadOnlyException(final Throwable cause) {
-            super(cause);
-        }
+
         public ReadOnlyException(final String cause, final Throwable root) {
             super(cause, root);
         }

--- a/eo-runtime/src/main/java/org/eolang/Data.java
+++ b/eo-runtime/src/main/java/org/eolang/Data.java
@@ -40,6 +40,7 @@ import java.util.regex.Pattern;
 /**
  * A data container.
  *
+ * @param <T> Data type.
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (200 lines)
  */

--- a/eo-runtime/src/main/java/org/eolang/Data.java
+++ b/eo-runtime/src/main/java/org/eolang/Data.java
@@ -41,6 +41,7 @@ import java.util.regex.Pattern;
  * A data container.
  *
  * @since 0.1
+ * @checkstyle ClassDataAbstractionCouplingCheck (200 lines)
  */
 public interface Data<T> {
 
@@ -51,14 +52,19 @@ public interface Data<T> {
     T take();
 
     final class Once<T> implements Data<T> {
+
         private final Data<T> src;
+
         private final AtomicReference<T> ref;
+
         private final Supplier<String> blank;
+
         public Once(final Data<T> data, final Supplier<String> txt) {
             this.src = data;
             this.ref = new AtomicReference<>();
             this.blank = txt;
         }
+
         @Override
         public String toString() {
             final T data = this.ref.get();
@@ -70,6 +76,7 @@ public interface Data<T> {
             }
             return txt;
         }
+
         @Override
         public T take() {
             if (this.ref.get() == null) {
@@ -80,6 +87,7 @@ public interface Data<T> {
     }
 
     final class ToPhi extends PhOnce {
+
         public ToPhi(final Object obj) {
             super(
                 () -> {
@@ -113,14 +121,18 @@ public interface Data<T> {
                 () -> ""
             );
         }
+
     }
 
     final class Value<T> extends PhDefault implements Data<T> {
+
         private final T val;
+
         public Value(final T value) {
             super(Phi.Φ);
             this.val = value;
         }
+
         @Override
         public String toString() {
             final String txt;
@@ -142,6 +154,7 @@ public interface Data<T> {
             }
             return txt;
         }
+
         @Override
         public T take() {
             return this.val;

--- a/eo-runtime/src/main/java/org/eolang/Dataized.java
+++ b/eo-runtime/src/main/java/org/eolang/Dataized.java
@@ -53,16 +53,16 @@ public final class Dataized {
             if (!(src instanceof Data)) {
                 src = src.attr("Δ").get();
             }
-        } catch (final Attr.Exception ex) {
-            throw new Attr.Exception(
-                String.format("Attribute failure at:\n%s", this.phi),
+        } catch (final Attr.IllegalAttrException ex) {
+            throw new Attr.IllegalAttrException(
+                String.format("Attribute failure at:%n%s", this.phi),
                 ex
             );
         }
         if (!(src instanceof Data)) {
-            throw new Attr.Exception(
+            throw new Attr.IllegalAttrException(
                 String.format(
-                    "The attribute Δ has %s instead of %s at:\n%s",
+                    "The attribute Δ has %s instead of %s at:%n%s",
                     src.getClass().getCanonicalName(),
                     Data.class.getCanonicalName(),
                     this.phi

--- a/eo-runtime/src/main/java/org/eolang/Main.java
+++ b/eo-runtime/src/main/java/org/eolang/Main.java
@@ -31,6 +31,7 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -97,10 +98,11 @@ public final class Main {
         try (BufferedReader input =
             new BufferedReader(
                 new InputStreamReader(
-                    Main.class.getResourceAsStream("version.txt"),
-                    StandardCharsets.UTF_8)
+                    Objects.requireNonNull(Main.class.getResourceAsStream("version.txt")),
+                    StandardCharsets.UTF_8
                 )
-            ) {
+            )
+        ) {
             this.stdout.printf(
                 "EOLANG Runtime v.%s",
                 input.lines().findFirst().get()

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -125,7 +125,7 @@ public abstract class PhDefault implements Phi, Cloneable {
     @Override
     public final Attr attr(final int pos) {
         if (this.order.isEmpty()) {
-            throw new Attr.Exception(
+            throw new Attr.IllegalAttrException(
                 String.format(
                     "There are no attributes here, can't get the %d-th one",
                     pos

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -90,7 +90,7 @@ public abstract class PhDefault implements Phi, Cloneable {
                 String.format(
                     "%s%s=%s",
                     ent.getKey(),
-                    idx >=0 ? String.format("(%d)", idx) : "",
+                    idx >= 0 ? String.format("(%d)", idx) : "",
                     ent.getValue().toString().replace("\n", PhDefault.REPLACEMENT)
                 )
             );

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -34,7 +34,7 @@ import java.util.Map;
  *
  * @since 0.1
  */
-public class PhDefault implements Phi, Cloneable {
+public abstract class PhDefault implements Phi, Cloneable {
 
     /**
      * Named attr format.

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -42,6 +42,7 @@ public class PhOnce implements Phi {
      * Ctor.
      *
      * @param data The object
+     * @param blank The string value
      */
     public PhOnce(final Data<Phi> data, final Supplier<String> blank) {
         this.object = new Data.Once<>(data, blank);

--- a/eo-runtime/src/main/java/org/eolang/Phi.java
+++ b/eo-runtime/src/main/java/org/eolang/Phi.java
@@ -98,6 +98,11 @@ public interface Phi {
         private static final int MAX = 64;
 
         /**
+         * Triple.
+         */
+        private static final int LEN = 3;
+
+        /**
          * Original.
          */
         private final Phi phi;
@@ -118,8 +123,8 @@ public interface Phi {
             if (txt.length() > Phi.Compact.MAX) {
                 txt = String.format(
                     "%s...%s",
-                    txt.substring(0, Phi.Compact.MAX - 3),
-                    txt.substring(Phi.Compact.MAX + 3)
+                    txt.substring(0, Phi.Compact.MAX - Phi.Compact.LEN),
+                    txt.substring(Phi.Compact.MAX + Phi.Compact.LEN)
                 );
             }
             return txt;

--- a/eo-runtime/src/main/java/org/eolang/Phi.java
+++ b/eo-runtime/src/main/java/org/eolang/Phi.java
@@ -39,6 +39,7 @@ public interface Phi {
      * The global scope object, which owns all other objects.
      *
      * @checkstyle ConstantNameCheck (5 lines)
+     * @checkstyle AnonInnerLengthCheck (30 lines)
      */
     Phi Φ = new Phi() {
         @Override

--- a/eo-runtime/src/main/java/org/eolang/Phi.java
+++ b/eo-runtime/src/main/java/org/eolang/Phi.java
@@ -37,6 +37,8 @@ public interface Phi {
 
     /**
      * The global scope object, which owns all other objects.
+     *
+     * @checkstyle ConstantNameCheck (5 lines)
      */
     Phi Φ = new Phi() {
         @Override

--- a/eo-runtime/src/test/java/org/eolang/AtVarargTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtVarargTest.java
@@ -37,7 +37,8 @@ public final class AtVarargTest {
     @Test
     public void appendsElements() {
         final Attr attr = new AtVararg();
-        final Phi phi = new PhDefault();
+        final Phi phi = new PhDefault() {
+        };
         attr.put(phi);
         attr.put(phi);
         MatcherAssert.assertThat(


### PR DESCRIPTION
Per #268 

1) Checkstyle: Remove all  complains, excluding JavadocChecks 
2) PMD: Variable naming & exception class naming