### PR TITLE
deps: use array.eo directly from eo-runtime

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -157,11 +157,6 @@ SOFTWARE.
       <groupId>org.glassfish</groupId>
       <artifactId>javax.json</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspileMojoTest.java
@@ -26,7 +26,7 @@ package org.eolang.maven;
 import com.jcabi.log.Logger;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.apache.commons.lang3.SystemUtils;
+import java.nio.file.Paths;
 import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
 import org.cactoos.Input;
 import org.cactoos.io.InputOf;
@@ -121,15 +121,11 @@ public final class TranspileMojoTest {
     @Test
     public void testRealCompilation(@TempDir final Path temp)
         throws Exception {
-        final String arpath;
-        if (SystemUtils.IS_OS_WINDOWS) {
-            arpath = "org/eolang/maven/win-array.eo";
-        } else {
-            arpath = "org/eolang/maven/array.eo";
-        }
         final String java = this.compile(
             temp,
-            new ResourceOf(arpath),
+            new InputOf(
+                Paths.get("../eo-runtime/src/main/eo/org/eolang/array.eo")
+            ),
             "EOorg/EOeolang/EOarray.java"
         );
         MatcherAssert.assertThat(java, Matchers.containsString("class"));

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/array.eo
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/array.eo
@@ -1,1 +1,0 @@
-../../../../../../../eo-runtime/src/main/eo/org/eolang/array.eo


### PR DESCRIPTION
In `eo-maven-plugin` tests, we now use directly original file `array.eo` (belonging to `eo-runtime`). No need to use symlink.
Both windows and linux support this.

Ref: #465