### PR TITLE
fix(eo-maven-plugin): get relative path of cwd

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Save.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Save.java
@@ -150,7 +150,9 @@ public final class Save {
     public static String rel(final Path file) {
         final String cwd = Paths.get("").toAbsolutePath().toString();
         String path = file.toAbsolutePath().toString();
-        if (path.startsWith(cwd)) {
+        if (path.equals(cwd)) {
+            path = "./";
+        } else if (path.startsWith(cwd)) {
             path = String.format(
                 "./%s",
                 path.substring(cwd.length() + 1)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SaveTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SaveTest.java
@@ -25,10 +25,12 @@ package org.eolang.maven;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.cactoos.text.Randomized;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -53,4 +55,11 @@ final class SaveTest {
         );
     }
 
+    @Test
+    void returnsRelativePathOfCurrentWorkingDirectory() {
+        MatcherAssert.assertThat(
+            Save.rel(Paths.get("")),
+            Matchers.is("./")
+        );
+    }
 }


### PR DESCRIPTION
Before, an error occured when we tried to get relative path of current working directory (`cwd`) by `Save#rel`.
Now we get `./` as relative path of `cwd`. By resolving this, we can now set in `eo-maven-plugin` following configuration without error :
```xml
<sourcesDir>${project.basedir}</sourcesDir>
```

Ref: #516