### PR TITLE
test(eo-runtime): reproduce bug EO app calls varargs func

### DIFF
--- a/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/runtime-tests.eo
@@ -208,3 +208,16 @@
     seq
       h.write func
       h.@ "Jeff"
+
+# It's currently broken. Now we should resolve it first
+# before enabling it by uncommenting.
+# [] > app-that-calls-varargs-func
+#   [] > app
+#     [args...] > f
+#       1 > a
+#       2 > @
+#     (f 1 2 3).eq 2 > @
+#   app > output
+#   output.eq TRUE > @
+[] > app-that-calls-varargs-func
+  TRUE > @

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EODataizeAppCallsVarargsFuncTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EODataizeAppCallsVarargsFuncTest.java
@@ -44,12 +44,12 @@ import org.junit.jupiter.api.Test;
  *
  * @since 0.22
  * @todo #414:30min Fix bug EO app calling a varargs func.
- *  We reproduced by a Java and EO test bug with exception `You can't overwrite X`
+ *  We reproduced by a Java and EO tests, the bug with exception `You can't overwrite X`
  *  when EO app try to call a function that uses varargs as parameter. Now, we must fix it
  *  and enable test below and eo test {@code [] > calls-varargs-func} located in
  *  `runtime-tests.eo`.
  */
-final class EODataizeVarargsFuncTest {
+final class EODataizeAppCallsVarargsFuncTest {
 
     @Test
     @Disabled
@@ -80,14 +80,11 @@ final class EODataizeVarargsFuncTest {
                         this,
                         (rho) -> {
                             Phi fvar = new PhCopy(new Fvarargs(rho));
-                            Phi var1 = new Data.ToPhi(1L);
-                            Phi var2 = new Data.ToPhi(2L);
-                            Phi var3 = new Data.ToPhi(3L);
-                            Phi fvard = new PhWith(fvar, 0, var1);
-                            fvard = new PhWith(fvard, 1, var2);
-                            fvard = new PhWith(fvard, 2, var3);
+                            fvar = new PhWith(fvar, 0, new Data.ToPhi(1L));
+                            fvar = new PhWith(fvar, 1, new Data.ToPhi(2L));
+                            fvar = new PhWith(fvar, 2, new Data.ToPhi(3L));
                             return new PhWith(
-                                new PhCopy(new PhMethod(fvard, "eq")), 0, new Data.ToPhi(2L)
+                                new PhCopy(new PhMethod(fvar, "eq")), 0, new Data.ToPhi(2L)
                             );
                         }
                     )
@@ -99,7 +96,7 @@ final class EODataizeVarargsFuncTest {
     /**
      * Varargs function sample.
      * {@code
-     *  [args] > f
+     *  [args...] > f
      *    1 > a
      *    2 > @
      * }

--- a/eo-runtime/src/test/java/EOorg/EOeolang/EODataizeVarargsFuncTest.java
+++ b/eo-runtime/src/test/java/EOorg/EOeolang/EODataizeVarargsFuncTest.java
@@ -1,0 +1,128 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2021 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package EOorg.EOeolang;
+
+import org.eolang.AtComposite;
+import org.eolang.AtOnce;
+import org.eolang.AtVararg;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhCopy;
+import org.eolang.PhDefault;
+import org.eolang.PhMethod;
+import org.eolang.PhWith;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests dataization of an EO app that calls a function
+ * with varargs.
+ *
+ * @since 0.22
+ * @todo #414:30min Fix bug EO app calling a varargs func.
+ *  We reproduced by a Java and EO test bug with exception `You can't overwrite X`
+ *  when EO app try to call a function that uses varargs as parameter. Now, we must fix it
+ *  and enable test below and eo test {@code [] > calls-varargs-func} located in
+ *  `runtime-tests.eo`.
+ */
+final class EODataizeVarargsFuncTest {
+
+    @Test
+    @Disabled
+    public void dataizesEOappThatCallsVarargsFunc() {
+        MatcherAssert.assertThat(
+            new Dataized(
+                new EOappThatCallsVarargsFunc(Phi.Φ)
+            ).take(Long.class),
+            Matchers.is(2L)
+        );
+    }
+
+    /**
+     * Main program sample.
+     * {@code
+     *  [] > app
+     *    (f 1 2 3).eq 2 > @
+     * }
+     * @since 0.22
+     */
+    private static class EOappThatCallsVarargsFunc extends PhDefault {
+        public EOappThatCallsVarargsFunc(Phi sigma) {
+            super(sigma);
+            this.add(
+                "φ",
+                new AtOnce(
+                    new AtComposite(
+                        this,
+                        (rho) -> {
+                            Phi fvar = new PhCopy(new Fvarargs(rho));
+                            Phi var1 = new Data.ToPhi(1L);
+                            Phi var2 = new Data.ToPhi(2L);
+                            Phi var3 = new Data.ToPhi(3L);
+                            Phi fvard = new PhWith(fvar, 0, var1);
+                            fvard = new PhWith(fvard, 1, var2);
+                            fvard = new PhWith(fvard, 2, var3);
+                            return new PhWith(
+                                new PhCopy(new PhMethod(fvard, "eq")), 0, new Data.ToPhi(2L)
+                            );
+                        }
+                    )
+                )
+            );
+        }
+    }
+
+    /**
+     * Varargs function sample.
+     * {@code
+     *  [args] > f
+     *    1 > a
+     *    2 > @
+     * }
+     * @since 0.22
+     */
+    @SuppressWarnings("unchecked")
+    private static class Fvarargs extends PhDefault {
+        public Fvarargs(final Phi sigma) {
+            super(sigma);
+            this.add("args", new AtVararg());
+            this.add(
+                "a",
+                new AtOnce(
+                    new AtComposite(this, (rho) -> new Data.ToPhi(1L))
+                )
+            );
+            this.add(
+                "φ",
+                new AtOnce(
+                    new AtComposite(this, (rho) -> new Data.ToPhi(2L))
+                )
+            );
+        }
+    }
+
+}

--- a/eo-runtime/src/test/java/org/eolang/DataizedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataizedTest.java
@@ -29,8 +29,10 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import EOorg.EOeolang.EOint;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -76,4 +78,102 @@ public final class DataizedTest {
         );
     }
 
+    /**
+     * Try to datarize an EO app that calls a varargs func.
+     * @todo #414:30min Fix bug execute an EO program calling a varargs func.
+     *  We reproduced by a test bug during execution with exception `You can't overwrite X`
+     *  when EO app try to call a function that uses varargs as parameter. Now, we must fix it
+     *  and disable the test (test below).
+     */
+    @Test
+    @Disabled
+    public void datarizesEOappCallingVarargsFunc() {
+        MatcherAssert.assertThat(
+            new Dataized(
+                new EOappCallingVarargsFunc(Phi.Φ)
+            ).take(Long.class),
+            Matchers.is(2L)
+        );
+    }
+
+    /**
+     * Main program sample.
+     * {@code
+     *  [] > app
+     *    (f 1 2 3).eq 2 > @
+     * }
+     * @since 0.22
+     */
+    private static class EOappCallingVarargsFunc extends PhDefault {
+        public EOappCallingVarargsFunc(Phi sigma) {
+            super(sigma);
+            this.add(
+                "φ",
+                new AtOnce(
+                    new AtComposite(
+                        this,
+                        (rho) -> {
+                            Phi fvar = new PhCopy(new DataizedTest.Fvarargs(rho));
+                            Phi var1 = new PhWith(
+                                new EOint(rho), "Δ", new Data.Value<>(1L)
+                            );
+                            Phi var2 = new PhWith(
+                                new EOint(rho), "Δ", new Data.Value<>(2L)
+                            );
+                            Phi var3 = new PhWith(
+                                new EOint(rho), "Δ", new Data.Value<>(3L)
+                            );
+                            Phi fvard = new PhWith(fvar, 0, var1);
+                            fvard = new PhWith(fvard, 1, var2);
+                            fvard = new PhWith(fvard, 2, var3);
+                            return new PhWith(
+                                new PhCopy(
+                                    new PhMethod(fvard, "eq")
+                                ),
+                                0,
+                                new PhWith(
+                                    new EOint(rho), "Δ", new Data.Value<>(2L)
+                                )
+                            );
+                        }
+                    )
+                )
+            );
+        }
+    }
+
+    /**
+     * Varargs function sample.
+     * {@code
+     *  [args] > f
+     *    1 > a
+     *    2 > @
+     * }
+     * @since 0.22
+     */
+    @SuppressWarnings("unchecked")
+    private static class Fvarargs extends PhDefault {
+        public Fvarargs(final Phi sigma) {
+            super(sigma);
+            this.add("args", new AtVararg());
+            this.add(
+                "a",
+                new AtOnce(
+                    new AtComposite(
+                        this,
+                        (rho) -> new PhWith(new EOint(rho), "Δ", new Data.Value<>(1L))
+                    )
+                )
+            );
+            this.add(
+                "φ",
+                new AtOnce(
+                    new AtComposite(
+                        this,
+                        (rho) -> new PhWith(new EOint(rho), "Δ", new Data.Value<>(2L))
+                    )
+                )
+            );
+        }
+    }
 }

--- a/eo-runtime/src/test/java/org/eolang/DataizedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataizedTest.java
@@ -29,7 +29,6 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
-import EOorg.EOeolang.EOint;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
@@ -114,26 +113,14 @@ public final class DataizedTest {
                         this,
                         (rho) -> {
                             Phi fvar = new PhCopy(new DataizedTest.Fvarargs(rho));
-                            Phi var1 = new PhWith(
-                                new EOint(rho), "Δ", new Data.Value<>(1L)
-                            );
-                            Phi var2 = new PhWith(
-                                new EOint(rho), "Δ", new Data.Value<>(2L)
-                            );
-                            Phi var3 = new PhWith(
-                                new EOint(rho), "Δ", new Data.Value<>(3L)
-                            );
+                            Phi var1 = new Data.ToPhi(1L);
+                            Phi var2 = new Data.ToPhi(2L);
+                            Phi var3 = new Data.ToPhi(3L);
                             Phi fvard = new PhWith(fvar, 0, var1);
                             fvard = new PhWith(fvard, 1, var2);
                             fvard = new PhWith(fvard, 2, var3);
                             return new PhWith(
-                                new PhCopy(
-                                    new PhMethod(fvard, "eq")
-                                ),
-                                0,
-                                new PhWith(
-                                    new EOint(rho), "Δ", new Data.Value<>(2L)
-                                )
+                                new PhCopy(new PhMethod(fvard, "eq")), 0, new Data.ToPhi(2L)
                             );
                         }
                     )
@@ -159,19 +146,13 @@ public final class DataizedTest {
             this.add(
                 "a",
                 new AtOnce(
-                    new AtComposite(
-                        this,
-                        (rho) -> new PhWith(new EOint(rho), "Δ", new Data.Value<>(1L))
-                    )
+                    new AtComposite(this, (rho) -> new Data.ToPhi(1L))
                 )
             );
             this.add(
                 "φ",
                 new AtOnce(
-                    new AtComposite(
-                        this,
-                        (rho) -> new PhWith(new EOint(rho), "Δ", new Data.Value<>(2L))
-                    )
+                    new AtComposite(this, (rho) -> new Data.ToPhi(2L))
                 )
             );
         }


### PR DESCRIPTION
EO app fails with an exception `You can't overwrite X` when it tries to call a varargs function. The error occurs within varargs function during its dataization. We reproduced it here by Java and EO test and introduced a todo to fix it.

Close: #414