### PR TITLE
Split workflows

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,5 +1,5 @@
 ---
-name: mvn
+name: linters
 on:
   push:
     branches:
@@ -10,28 +10,6 @@ on:
       - master
     paths-ignore: ['paper/**', 'sandbox/**']
 jobs:
-  test:
-    name: Tests
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-        java: [11, 17]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Java ${{ matrix.java }}
-        uses: actions/setup-java@v1
-        with:
-          java-version: ${{ matrix.java }}
-      - uses: actions/cache@v1
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
-      - name: Test
-        run: mvn clean test integration-test --errors --batch-mode
-
   qulice:
     name: Qulice
     runs-on: ubuntu-latest

--- a/.github/workflows/mvn-linux.yml
+++ b/.github/workflows/mvn-linux.yml
@@ -1,0 +1,33 @@
+---
+name: mvn-linux
+on:
+  push:
+    branches:
+      - master
+    paths-ignore: ['paper/**', 'sandbox/**']
+  pull_request:
+    branches:
+      - master
+    paths-ignore: ['paper/**', 'sandbox/**']
+jobs:
+  test:
+    name: Tests
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        java: [11, 17]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
+      - name: Test
+        run: mvn clean test integration-test --errors --batch-mode

--- a/.github/workflows/mvn-windows.yml
+++ b/.github/workflows/mvn-windows.yml
@@ -1,0 +1,33 @@
+---
+name: mvn-windows
+on:
+  push:
+    branches:
+      - master
+    paths-ignore: ['paper/**', 'sandbox/**']
+  pull_request:
+    branches:
+      - master
+    paths-ignore: ['paper/**', 'sandbox/**']
+jobs:
+  test:
+    name: Tests
+    strategy:
+      matrix:
+        os: [windows-latest]
+        java: [11, 17]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-jdk-${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
+      - name: Test
+        run: mvn clean test integration-test --errors --batch-mode


### PR DESCRIPTION
Windows build fails and cancels all other jobs.
To prevent that, lets split the workflow in three.