### PR TITLE
Remove Java code from Grammar

### DIFF
--- a/eo-parser/src/main/antlr4/org/eolang/parser/Program.g4
+++ b/eo-parser/src/main/antlr4/org/eolang/parser/Program.g4
@@ -6,20 +6,6 @@ grammar Program;
 
 tokens { TAB, UNTAB }
 
-@lexer::members {
-  private int currentTabs = 0;
-  private LinkedList<Token> tokens = new LinkedList<>();
-  @Override
-  public Token nextToken() {
-    return this.tokens.isEmpty() ? super.nextToken() : this.tokens.poll();
-  }
-  public void emitToken(int t, int line) {
-    CommonToken tkn = new CommonToken(t, "");
-    tkn.setLine(line);
-    this.tokens.offer(tkn);
-  }
-}
-
 program
   :
   license?
@@ -267,20 +253,7 @@ EOL
   ('\n' | '\r\n')
   ('\n' | '\r\n')?
   SPACE*
-  {
-    int tabs = getText().replaceAll("[\r]?[\n]", "").length() / 2;
-    if (tabs < this.currentTabs) {
-      for (int i = 0; i < this.currentTabs - tabs; ++i) {
-        this.emitToken(ProgramParser.UNTAB, getLine() + 1);
-        this.emitToken(ProgramParser.EOL, getLine() + 1);
-      }
-    } else if (tabs > this.currentTabs) {
-      for (int i = 0; i < tabs - this.currentTabs; ++i) {
-        this.emitToken(ProgramParser.TAB, getLine() + 1);
-      }
-    }
-    this.currentTabs = tabs;
-  }
+  { }
   ;
 
 fragment BYTE: [0-9A-F][0-9A-F];

--- a/eo-parser/src/main/java/org/eolang/parser/EoLexer.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoLexer.java
@@ -1,0 +1,137 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2021 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.parser;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedList;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonToken;
+import org.antlr.v4.runtime.RuleContext;
+import org.antlr.v4.runtime.Token;
+import org.cactoos.Text;
+import org.cactoos.io.InputStreamOf;
+
+/**
+ * Indentation-aware Lexer.
+ *
+ * @since 1.0
+ * @todo #430:30m Remove EoLexer.action method.
+ *  Having an action is not necessary, it should
+ *  be enough to look up upcoming token from
+ *  nextToken(). Also remove empty action for the
+ *  grammar.
+ */
+public final class EoLexer extends ProgramLexer {
+    /**
+     * Generated tokes.
+     */
+    private final Deque<Token> tokens;
+
+    /**
+     * Indentation level.
+     */
+    private final Deque<Integer> indent;
+
+    /**
+     * Ctor.
+     * @param txt Source code.
+     * @throws IOException If fails.
+     */
+    public EoLexer(final Text txt) throws IOException {
+        this(CharStreams.fromStream(new InputStreamOf(txt)));
+    }
+
+    /**
+     * Ctor.
+     * @param stream Char stream.
+     */
+    private EoLexer(final CharStream stream) {
+        super(stream);
+        this.indent = new LinkedList<>(
+            Collections.singletonList(0)
+        );
+        this.tokens = new LinkedList<>();
+    }
+
+    @Override
+    public Token nextToken() {
+        final Token result;
+        if (this.tokens.isEmpty()) {
+            result = super.nextToken();
+        } else {
+            result = this.tokens.poll();
+        }
+        return result;
+    }
+
+    @Override
+    public void action(final RuleContext ctx, final int rindx, final int aindx) {
+        if (rindx == this.getRuleIndexMap().get("EOL")) {
+            final int tabs = this.getText().replaceAll("[\r\n]", "").length() / 2;
+            final int last = this.indent.peekLast();
+            final int shift = tabs - last;
+            if (shift < 0) {
+                this.emitDedent(-shift);
+            } else if (shift > 0) {
+                this.emitIndent(shift);
+            }
+            this.indent.add(tabs);
+        }
+    }
+
+    /**
+     * Indent.
+     * @param shift Number of tabs
+     */
+    private void emitIndent(final int shift) {
+        for (int idx = 0; idx < shift; ++idx) {
+            this.emitToken(ProgramParser.TAB);
+        }
+    }
+
+    /**
+     * De-indent.
+     * @param shift Number of un-tabs.
+     */
+    private void emitDedent(final int shift) {
+        for (int idx = 0; idx < shift; ++idx) {
+            this.emitToken(ProgramParser.UNTAB);
+            this.emitToken(ProgramParser.EOL);
+        }
+    }
+
+    /**
+     * Emit token at the next line.
+     * @param type Type.
+     */
+    private void emitToken(final int type) {
+        final CommonToken tkn = new CommonToken(type, this.getRuleNames()[type]);
+        tkn.setLine(this.getLine() + 1);
+        this.tokens.offer(tkn);
+    }
+
+}

--- a/eo-parser/src/main/java/org/eolang/parser/Syntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Syntax.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.util.List;
 import org.antlr.v4.runtime.ANTLRErrorListener;
 import org.antlr.v4.runtime.BaseErrorListener;
-import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
@@ -38,7 +37,6 @@ import org.cactoos.Input;
 import org.cactoos.Output;
 import org.cactoos.Text;
 import org.cactoos.io.InputOf;
-import org.cactoos.io.InputStreamOf;
 import org.cactoos.io.TeeInput;
 import org.cactoos.list.ListOf;
 import org.cactoos.scalar.LengthOf;
@@ -110,11 +108,7 @@ public final class Syntax {
                 );
             }
         };
-        final ProgramLexer lexer = new ProgramLexer(
-            CharStreams.fromStream(
-                new InputStreamOf(this.normalize())
-            )
-        );
+        final ProgramLexer lexer = new EoLexer(this.normalize());
         lexer.removeErrorListeners();
         lexer.addErrorListener(errors);
         final ProgramParser parser = new ProgramParser(

--- a/eo-parser/src/test/java/org/eolang/parser/EoLexerTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoLexerTest.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2021 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.parser;
+
+import java.io.IOException;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link EoLexer}.
+ *
+ * @since 1.0
+ */
+final class EoLexerTest {
+    @Test
+    void emitsTab() throws IOException {
+        final EoLexer lexer = new EoLexer(
+            new TextOf("\n  ")
+        );
+        lexer.nextToken();
+        MatcherAssert.assertThat(
+            lexer.nextToken().getType(),
+            Matchers.is(
+                ProgramParser.TAB
+            )
+        );
+    }
+
+    @Test
+    void emitsUntab() throws IOException {
+        final EoLexer lexer = new EoLexer(
+            new TextOf("\n  \n")
+        );
+        lexer.nextToken();
+        lexer.nextToken();
+        lexer.nextToken();
+        MatcherAssert.assertThat(
+            lexer.nextToken().getType(),
+            Matchers.is(
+                ProgramParser.UNTAB
+            )
+        );
+    }
+}


### PR DESCRIPTION
Per #390 

- Remove Java code from Grammar

In attempt to flatten the grammar, similar to this example (https://github.com/antlr/grammars-v4/blob/master/python/tiny-python/tiny-grammar-without-actions/Python3.g4).
At the end the grammar will not have only mentions of TAB or UNTAB, thus making `htail` and `tail` unnecessary.

Note: this change is also beneficial for https://github.com/cqfn/eo/issues/494 https://github.com/cqfn/eo/issues/485
