### PR TITLE
Fix mistake in calculus.tex

### DIFF
--- a/paper/sections/calculus.tex
+++ b/paper/sections/calculus.tex
@@ -162,7 +162,7 @@ is created by another abstract object, for example:
   \begin{equation}
   \begin{split}
   & x \mapsto \llbracket y \mapsto \llbracket z \mapsto t \rrbracket \rrbracket \br
-  & x.y.z = x \br
+  & x.y.\rho = x \br
   & x.y.z.\rho = y.
   \end{split}
   \end{equation}


### PR DESCRIPTION
`x.y.z = y` does not make any sense. It seems it should be `x.y.𝜌 = y`.