### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ create a file `pom.xml` with this content (it's just a sample):
           </execution>
         </executions>
         <configuration>
-          <mainClass>org.eolang.phi.Main</mainClass>
+          <mainClass>org.eolang.Main</mainClass>
           <arguments>
             <argument>main</argument>
             <argument>2008</argument>


### PR DESCRIPTION
`mvn clean test` is not passing when `org.eolang.phi.Main` because `Main.class` is in just `org.eolang`