### PR TITLE
(#605) - Ensure INT represented as 8 bytes

### DIFF
--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_char.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_char.java
@@ -43,7 +43,7 @@ public class EObytes$EOas_char extends PhDefault {
     public EObytes$EOas_char(final Phi sigma) {
         super(sigma);
         this.add("φ", new AtComposite(this, rho ->
-            new Data.ToPhi(new Param(rho).fromBytes(char.class)))
+            new Data.ToPhi(new Param(rho).fromBytes(Character.class)))
         );
     }
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_char.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_char.java
@@ -42,10 +42,9 @@ public class EObytes$EOas_char extends PhDefault {
 
     public EObytes$EOas_char(final Phi sigma) {
         super(sigma);
-        this.add("φ", new AtComposite(this, rho -> {
-            final byte[] array = new Param(rho).strong(byte[].class);
-            return new Data.ToPhi(ByteBuffer.wrap(array).getChar());
-        }));
+        this.add("φ", new AtComposite(this, rho ->
+            new Data.ToPhi(new Param(rho).fromBytes(char.class)))
+        );
     }
 
 }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_float.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_float.java
@@ -42,10 +42,9 @@ public class EObytes$EOas_float extends PhDefault {
 
     public EObytes$EOas_float(final Phi sigma) {
         super(sigma);
-        this.add("φ", new AtComposite(this, rho -> {
-            final byte[] array = new Param(rho).strong(byte[].class);
-            return new Data.ToPhi(ByteBuffer.wrap(array).getDouble());
-        }));
+        this.add("φ", new AtComposite(this, rho ->
+            new Data.ToPhi(new Param(rho).fromBytes(Double.class)))
+        );
     }
 
 }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_int.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOas_int.java
@@ -44,7 +44,7 @@ public class EObytes$EOas_int extends PhDefault {
     public EObytes$EOas_int(final Phi sigma) {
         super(sigma);
         this.add("φ", new AtComposite(this, rho ->
-	    new Data.ToPhi(new Param(rho).fromBytes(BigInteger.class).longValueExact())
+	        new Data.ToPhi(new Param(rho).fromBytes(Long.class))
         ));
     }
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOor.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EObytes$EOor.java
@@ -39,10 +39,10 @@ public class EObytes$EOor extends PhDefault {
         super(sigma);
         this.add("b", new AtFree());
         this.add("φ", new AtComposite(this, rho -> {
-            final byte[] array = new Param(rho).strong(byte[].class);
-            final byte[] another = new Param(rho, "b").strong(byte[].class);
-            return new Data.ToPhi(
-                new BigInteger(array).or(new BigInteger(another)).toByteArray()
+            final BigInteger fst = new Param(rho).fromBytes(BigInteger.class);
+			final BigInteger snd = new Param(rho, "b").fromBytes(BigInteger.class);
+			return new Data.ToPhi(
+                fst.or(snd).toByteArray()
             );
         }));
     }

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOchar$EOas_bytes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOchar$EOas_bytes.java
@@ -43,10 +43,7 @@ public class EOchar$EOas_bytes extends PhDefault {
     public EOchar$EOas_bytes(final Phi sigma) {
         super(sigma);
         this.add("φ", new AtComposite(this, rho -> new Data.ToPhi(
-            ByteBuffer.allocate(Character.BYTES).putChar(
-                new Param(rho).strong(Character.class)
-            ).array()
-
+            new Param(rho).asBytes()
         )));
     }
 

--- a/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOas_bytes.java
+++ b/eo-runtime/src/main/java/EOorg/EOeolang/EOfloat$EOas_bytes.java
@@ -43,9 +43,7 @@ public class EOfloat$EOas_bytes extends PhDefault {
     public EOfloat$EOas_bytes(final Phi sigma) {
         super(sigma);
         this.add("φ", new AtComposite(this, rho -> new Data.ToPhi(
-            ByteBuffer.allocate(Double.BYTES).putDouble(
-                new Param(rho).strong(Double.class)
-            ).array()
+            new Param(rho).asBytes()
         )));
     }
 

--- a/eo-runtime/src/main/java/org/eolang/Param.java
+++ b/eo-runtime/src/main/java/org/eolang/Param.java
@@ -26,6 +26,7 @@ package org.eolang;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 /**
  * Param of an object (convenient retrieval mechanism).
@@ -112,7 +113,29 @@ public final class Param {
         final Object res;
         if (BigInteger.class.equals(type)) {
             res = new BigInteger(ret);
-        } else {
+        }
+        else if (Long.class.equals(type)) {
+            if (ret.length == 1) {
+                res = (long) ret[0];
+            }
+            else {
+                final byte[] cpy = new byte[Long.BYTES];
+                cpy[0] = ret[0];
+                int posx = cpy.length;
+                int posy = ret.length;
+                while (posy-- > 1 && posx-- > 1) {
+                    cpy[posx] = ret[posy];
+                }
+                res = ByteBuffer.wrap(cpy).getLong();
+            }
+        }
+        else if (Character.class.equals(type)) {
+            res = ByteBuffer.wrap(ret).getChar();
+        }
+        else if (Double.class.equals(type)) {
+            res = ByteBuffer.wrap(ret).getDouble();
+        }
+        else {
             throw new ExFailure(
                 String.format(
                     "Unsupported type: '%s'",
@@ -131,7 +154,13 @@ public final class Param {
 	    final Object ret = this.weak();
 	    final byte[] res;
 	    if (Long.class.isInstance(ret)) {
-	        res = BigInteger.valueOf((long) ret).toByteArray();
+	        res = ByteBuffer.allocate(Long.BYTES).putLong((long) ret).array();
+	    }
+	    else if (Character.class.isInstance(ret)) {
+	        res = ByteBuffer.allocate(Character.BYTES).putChar((char) ret).array();
+	    }
+	    else if (Double.class.isInstance(ret)) {
+	        res = ByteBuffer.allocate(Double.BYTES).putDouble((double) ret).array();
 	    } else {
 	        throw new ExFailure(
 	            String.format(

--- a/eo-runtime/src/test/eo/org/eolang/bytes-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/bytes-tests.eo
@@ -161,3 +161,11 @@
     01-.as-bool
     not.
       00-.as-bool
+
+[] > bitwise-works-negative
+  eq. > @
+    as-int.
+      or.
+        -127.as-bytes
+        127.as-bytes
+    -1

--- a/eo-runtime/src/test/eo/org/eolang/char-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/char-tests.eo
@@ -44,7 +44,7 @@
     'Ф'
     'Ф'
 
-[] > to-bytes-and-backwards
+[] > to-bytes-and-backwards-char
   eq. > @
     'Ф'
     as-char.

--- a/eo-runtime/src/test/eo/org/eolang/gray/ram-tests.eo
+++ b/eo-runtime/src/test/eo/org/eolang/gray/ram-tests.eo
@@ -47,3 +47,11 @@
     eq.
       data
       66-67-68-69
+
+[] > writes-integer-to-ram
+  ram 1024 > r
+  3.as-bytes > b
+  r.write 0 b > w
+  and. > @
+    w.eq TRUE
+    (r.read 0 8).as-int.eq 3


### PR DESCRIPTION
Per #605 

- Copy bytes with padding when converting to INT